### PR TITLE
Updated to support netcoreapp3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 obj
 *.user
+.idea

--- a/Base64Extensions/Base64Extensions.csproj
+++ b/Base64Extensions/Base64Extensions.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Reece Russell</Authors>
     <Company>Reece Russell</Company>
@@ -13,6 +12,7 @@
     <PackageTags>base64, encoding, decoding</PackageTags>
     <Version>0.3.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Base64Extensions/Base64Extensions.csproj
+++ b/Base64Extensions/Base64Extensions.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/reecerussell/base64-extensions</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>base64, encoding, decoding</PackageTags>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
To support `netcoreapp3.1`, I've updated the target frameworks to support `netstandard2.1` as a more generic approach than just targeting `net5.0`.