### PR TITLE
Add overrides to expose `bytesWritten`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '6.x'
 
       - name: Restore
         run: dotnet restore Base64Extensions/Base64Extensions.csproj
@@ -47,7 +47,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0'
+          dotnet-version: '6.0'
 
       - name: Restore
         run: dotnet restore Base64Extensions.Tests/Base64Extensions.Tests.csproj
@@ -75,7 +75,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0'
+          dotnet-version: '6.0'
 
       - name: Publish Base64Extensions
         run: dotnet nuget push packages/Base64Extensions.*.*.*.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://www.nuget.org/api/v2/package

--- a/Base64Extensions.Tests/Base64ConvertTests.cs
+++ b/Base64Extensions.Tests/Base64ConvertTests.cs
@@ -13,12 +13,32 @@ namespace Base64Extensions.Tests
         {
             Base64Convert.Encode(value).Should().Be(expected);
         }
+        
+        [Theory]
+        [InlineData("Hello World", "SGVsbG8gV29ybGQ=", 16)]
+        [InlineData("Hello World ", "SGVsbG8gV29ybGQg", 16)]
+        public void Encode_GivenPlainTextValue_ReturnsEncodedBase64StringWithBytesWritten(
+            string value, string expected, int expectedBytesWritten)
+        {
+            Base64Convert.Encode(value, out var bytesWritten).Should().Be(expected);
+            bytesWritten.Should().Be(expectedBytesWritten);
+        }
 
         [Theory]
         [InlineData("Hello World", "SGVsbG8gV29ybGQ")]
         public void Encode_GivenPlainTextAndUrlSafeFlag_ReturnsUrlSafeBase64String(string value, string expected)
         {
             Base64Convert.Encode(value, true).Should().Be(expected);
+        }
+        
+        [Theory]
+        [InlineData("Hello World", "SGVsbG8gV29ybGQ", 15)]
+        public void Encode_GivenPlainTextAndUrlSafeFlag_ReturnsUrlSafeBase64StringWithBytesWritten(
+            string value, string expected, int expectedBytesWritten)
+        {
+            var encoded = Base64Convert.Encode(value, true, out var bytesWritten);
+            encoded.Should().Be(expected);
+            bytesWritten.Should().Be(expectedBytesWritten);
         }
 
         [Fact]
@@ -37,6 +57,25 @@ namespace Base64Extensions.Tests
 
             encString.Should().Be("ocu7BkU2bu1mq+yB2dL/4A==");
         }
+        
+        [Fact]
+        public void Encode_NotGivenUrlSafeFlag_ReturnsStandardBase64WithBytesWritten()
+        {
+            var bytes = new byte[]
+            {
+                161, 203, 187, 6,
+                69, 54, 110, 237,
+                102, 171, 236, 129,
+                217, 210, 255, 224
+            };
+
+            var encoded = Base64Convert.Encode(bytes, out var bytesWritten);
+            
+            var encString = Encoding.UTF8.GetString(encoded);
+            encString.Should().Be("ocu7BkU2bu1mq+yB2dL/4A==");
+
+            bytesWritten.Should().Be(24);
+        }
 
         [Fact]
         public void Encode_GivenUrlSafeFlag_ReturnsUrlSafeBase64()
@@ -53,6 +92,25 @@ namespace Base64Extensions.Tests
             var encString = Encoding.UTF8.GetString(encoded);
 
             encString.Should().Be("ocu7BkU2bu1mq-yB2dL_4A");
+        }
+        
+        [Fact]
+        public void Encode_GivenUrlSafeFlag_ReturnsUrlSafeBase64WithBytesWritten()
+        {
+            var bytes = new byte[]
+            {
+                161, 203, 187, 6,
+                69, 54, 110, 237,
+                102, 171, 236, 129,
+                217, 210, 255, 224
+            };
+
+            var encoded = Base64Convert.Encode(bytes, true, out var bytesWritten);
+            
+            var encString = Encoding.UTF8.GetString(encoded);
+            encString.Should().Be("ocu7BkU2bu1mq-yB2dL_4A");
+
+            bytesWritten.Should().Be(22);
         }
 
         [Theory]

--- a/Base64Extensions.Tests/Base64Extensions.Tests.csproj
+++ b/Base64Extensions.Tests/Base64Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Base64Extensions.Tests/Base64Extensions.Tests.csproj
+++ b/Base64Extensions.Tests/Base64Extensions.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -14,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Base64Extensions/Base64Extensions.csproj
+++ b/Base64Extensions/Base64Extensions.csproj
@@ -13,6 +13,7 @@
     <Version>0.4.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+    <PackageVersion>0.5.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When encoding data to URL-safe base64, using the `Base64.GetMaxEncodedToUtf8Length` function in .NET you can be left with the padding unaccounted for. By adding overloads to expose this value, the padding can be taken care of.